### PR TITLE
Fix extra GPU mem cost on rank 0 when using DDP

### DIFF
--- a/deepmd_pt/train/training.py
+++ b/deepmd_pt/train/training.py
@@ -155,6 +155,7 @@ class Trainer(object):
             self.wrapper.load_state_dict(state_dict)
 
         if dist.is_initialized():
+            torch.cuda.set_device(LOCAL_RANK)
             # DDP will guarantee the model parameters are identical across all processes
             self.wrapper = DDP(
                 self.wrapper,


### PR DESCRIPTION
We observed that rank 0 has more threads than other rank, each holding a fragment of GPU memory. This will cause GPU 0 becomes the bottleneck of max batch size. We follow the missing step in [DDP tutorial](https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html) to fix this bug. Reference for [a similar case](https://discuss.pytorch.org/t/does-ddp-with-torchrun-need-torch-cuda-set-device-device/178723).